### PR TITLE
style: change happiness page background to black with dark theme

### DIFF
--- a/happiness/index.html
+++ b/happiness/index.html
@@ -26,8 +26,8 @@
             background: linear-gradient(90deg, rgba(252, 252, 252, 1) 0%, rgba(255, 0, 0, 1) 100%); */
             image-resolution: fill;
             height: 100%;
-            background-color: #f9f9f9;
-
+            background-color: #000000;
+            color: #ffffff;
 
             background-position: center;
             background-repeat: no-repeat;
@@ -88,7 +88,7 @@
 
         .back {
 
-            background-color: #ffffff;
+            background-color: #1a1a1a;
             padding: 1%;
             display: block;
 
@@ -100,7 +100,7 @@
                     hsla(263, 88%, 45%, 0.5) 100%); */
             /* background: rgb(246,246,246);
 background: linear-gradient(270deg, rgba(246,246,246,1) 0%, rgba(255,0,0,1) 100%); */
-            background: f9f9f9;
+            background: #2a2a2a;
         }
 
 
@@ -128,8 +128,8 @@ background: linear-gradient(270deg, rgba(246,246,246,1) 0%, rgba(255,0,0,1) 100%
         } */
         a {
             flex: 1;
-            background-color: #686767;
-            color: #696969;
+            background-color: #1a1a1a;
+            color: #cccccc;
             padding: 0.5rem;
             text-align: left;
             text-decoration: none;
@@ -144,7 +144,7 @@ background: linear-gradient(270deg, rgba(246,246,246,1) 0%, rgba(255,0,0,1) 100%
 
         a:hover {
             text-decoration: none;
-            color: #000;
+            color: #ffffff;
             transform: scale3d(1.1, 1.1, 1);
 
         }
@@ -161,7 +161,7 @@ background: linear-gradient(270deg, rgba(246,246,246,1) 0%, rgba(255,0,0,1) 100%
             font-size: 65px;
             font-weight: 550;
             font-size: 72px;
-            background: -webkit-linear-gradient(#000000, #191919, #333333, #4C4C4C);
+            background: -webkit-linear-gradient(#ffffff, #cccccc, #aaaaaa, #888888);
             background-clip: text;
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;


### PR DESCRIPTION
## What changed
Changed the Happiness @ Walkover page (`happiness/index.html`) to a full black background with a matching dark theme:
- `body` background changed from `#f9f9f9` to `#000000`, text colour set to `#ffffff`
- `.back` card background changed from `#ffffff` to `#1a1a1a`
- Link colours updated from grey (`#696969`) to light (`#cccccc`), hover to `#ffffff`
- Main heading gradient updated from dark-on-light to light-on-dark

## Why
HR requested a full page black colour change for the Happiness @ Walkover page.

## Notes
All changes confined to the CSS in `happiness/index.html`. No structural HTML changes.